### PR TITLE
refactor: add ´node_modules´ and ´.next´ to ´.secretlintignore´ file

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -1,1 +1,3 @@
 .env.development
+.next
+node_modules


### PR DESCRIPTION
Refactor required to stop `secretlint` from checking `node_modules` and `.next`.